### PR TITLE
[1.x] fix: catch InvalidArgumentException from formatContent() on legacy posts

### DIFF
--- a/src/Listener/AddDiscussionThumbnail.php
+++ b/src/Listener/AddDiscussionThumbnail.php
@@ -43,7 +43,15 @@ class AddDiscussionThumbnail
             && ($cached['date'] === null || $post->edited_at->isAfter($cached['date']));
 
         if ($cached === false || $stale) {
-            $content = $post->formatContent();
+            try {
+                $content = $post->formatContent();
+            } catch (\InvalidArgumentException $e) {
+                // Post content is not valid s9e XML (e.g. plain-text legacy content).
+                // Cache as no-image so we don't re-attempt on every request.
+                $this->cache->forever($key, ['url' => null, 'date' => $post->edited_at]);
+
+                return [];
+            }
 
             if (!$content) {
                 $this->cache->forever($key, ['url' => null, 'date' => null]);


### PR DESCRIPTION
## Summary

Fixes a crash reported by users installing the extension on forums that have posts with plain-text content (e.g. migrated from another forum platform). These posts are not valid s9e XML, so calling `formatContent()` throws `InvalidArgumentException` from the s9e renderer, which propagated up and corrupted the JSON API response.

The fix wraps the `formatContent()` call in a try/catch. On failure, a no-image result is cached against the post (with its current `edited_at`) so we don't retry on every request. The post will be re-scanned if it is later edited.

## Test plan

- [ ] Forums with legacy plain-text posts no longer crash on the discussion list
- [ ] Normal posts with valid s9e XML continue to have thumbnails extracted correctly
- [ ] A post that fails rendering is cached and doesn't retry on every page load
- [ ] PHPStan passes (`composer analyse:phpstan`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)